### PR TITLE
Add fix for #2: delete layer context when destroying XrInstance

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Each function must be registered. To do so, you should add a line similar to thi
 functions.emplace_back("xrEndFrame", PFN_xrVoidFunction(thisLayer_xrEndFrame));
 ```
 
+Due to the lifetime of API layers being tied to the OpenXR instance, we need to be able to initialize and cleaup the layer context when applications create and destroy their OpenXR instance, in case they do it multiple times. One example of an application with that behavior is Microsoft Flight Simulator 2020. Failing to do so causes problems (see issue #2).
+
+Thus, all layers created with this framework will, at miminum, hook the `xrDestroyInstance` function. Please do not remove or disable the hook for this funciton, or you may have created a semi-silent bug that will crashes *some* applications, but not others!
+
 ## Layer implemented extensions
 
 API Layers *can* implement OpenXR instance extensions.

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -52,6 +52,12 @@ void OpenXRLayer::CreateLayerContext(PFN_xrGetInstanceProcAddr getInstanceProcAd
 		this_layer->functions[shim.functionName] = shim;
 }
 
+void OpenXRLayer::DestroyLayerContext()
+{
+	delete this_layer;
+	this_layer = nullptr;
+}
+
 OpenXRLayer& OpenXRLayer::GetLayerContext()
 {
 	if (this_layer)

--- a/src/layer.hpp
+++ b/src/layer.hpp
@@ -39,6 +39,9 @@ public:
 
 	static void CreateLayerContext(PFN_xrGetInstanceProcAddr getInstanceProcAddr, const std::vector<ShimFunction>& shims = {});
 
+	//This function must be called as part of the instance destruction hook
+	static void DestroyLayerContext();
+
 	static OpenXRLayer& GetLayerContext();
 	XrResult GetInstanceProcAddr(XrInstance instance, const char* name, PFN_xrVoidFunction* function);
 	void LoadDispatchTable(XrInstance instance);

--- a/src/layer_shims.cpp
+++ b/src/layer_shims.cpp
@@ -5,7 +5,24 @@
 // Initial Author: Arthur Brainville <ybalrid@ybalrid.info>
 
 #include "layer_shims.hpp"
+
+#include <cassert>
 #include <iostream>
+
+//IMPORTANT: to allow for multiple instance creation/destruction, the contect of the layer must be re-initialized when the instance is being destroyed.
+//Hooking xrDestroyInstance is the best way to do that.
+XRAPI_ATTR XrResult XRAPI_CALL thisLayer_xrDestroyInstance(
+	XrInstance instance)
+{
+	PFN_xrDestroyInstance nextLayer_xrDestroyInstance = GetNextLayerFunction(xrDestroyInstance);
+
+	OpenXRLayer::DestroyLayerContext();
+
+	assert(nextLayer_xrDestroyInstance != nullptr);
+	return nextLayer_xrDestroyInstance(instance);
+}
+
+
 
 //Define the functions implemented in this layer like this:
 XRAPI_ATTR XrResult XRAPI_CALL thisLayer_xrEndFrame(XrSession session,
@@ -42,6 +59,7 @@ XRAPI_ATTR XrResult XRAPI_CALL thisLayer_xrTestMeTEST(XrSession session)
 std::vector<OpenXRLayer::ShimFunction> ListShims()
 {
 	std::vector<OpenXRLayer::ShimFunction> functions;
+	functions.emplace_back("xrDestroyInstance", PFN_xrVoidFunction(thisLayer_xrDestroyInstance));
 
 	//List every functions that is callable on this API layer
 	functions.emplace_back("xrEndFrame", PFN_xrVoidFunction(thisLayer_xrEndFrame));


### PR DESCRIPTION
This fixes works and was backported from another protect build around this template. Just need to double check that a empty layer built with this repo and loaded with MSFS2020 do not crash the game.

Fix #2 